### PR TITLE
Improve live rendering for optics and texture sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1747,6 +1747,62 @@
             '8mm 50D': './assets/grain/8mm50D.png'
         };
         const dustSources = Array.from({length: 20}, (_, i) => `./assets/grain/dust${(i + 1).toString().padStart(2, '0')}.png`);
+        const LIVE_FULL_RENDER_SLIDER_IDS = new Set([
+            // Optics sliders (excluding special preview-based ones)
+            'mtfMask', 'mtfSoftness', 'diffusionRadius', 'diffusionStrength',
+            'diffusionRadiusB', 'diffusionStrengthB', 'diffusionRadiusC', 'diffusionStrengthC',
+            'diffusionTintR', 'diffusionTintG', 'diffusionTintB', 'diffusionSpread',
+            'diffusionGamma', 'diffusionIntensity', 'diffusionRadiusD', 'diffusionStrengthD',
+            'diffusionRadiusE', 'diffusionStrengthE', 'diffusionRadiusF', 'diffusionStrengthF',
+            'diffusionTint2R', 'diffusionTint2G', 'diffusionTint2B', 'diffusionSpread2',
+            'diffusionGamma2', 'diffusionIntensity2',
+            // Texture sliders
+            'grainScale', 'grainIntensity', 'grainSaturation', 'grainReduceShadows',
+            'grainShadowSat', 'grainReduceHighlights', 'grainHighlightSat', 'highPassRadius',
+            'highPassOpacity',
+            // Dust sliders
+            'dustMoveX', 'dustMoveY', 'dustRotate'
+        ]);
+        const LIVE_FULL_RENDER_MIN_INTERVAL = 90;
+        const liveFullRenderStates = new Map();
+        function triggerLiveFullRender(sliderId, immediate = false) {
+            if (!LIVE_FULL_RENDER_SLIDER_IDS.has(sliderId) || !imageTexture) return;
+            let state = liveFullRenderStates.get(sliderId);
+            if (!state) {
+                state = { lastTime: 0, timer: null };
+                liveFullRenderStates.set(sliderId, state);
+            }
+            const now = performance.now();
+            if (immediate) {
+                if (state.timer) {
+                    clearTimeout(state.timer);
+                    state.timer = null;
+                }
+                state.lastTime = now;
+                if (isSimplePreviewing) isSimplePreviewing = false;
+                render();
+                return;
+            }
+            const elapsed = now - state.lastTime;
+            if (elapsed >= LIVE_FULL_RENDER_MIN_INTERVAL) {
+                state.lastTime = now;
+                if (state.timer) {
+                    clearTimeout(state.timer);
+                    state.timer = null;
+                }
+                if (isSimplePreviewing) isSimplePreviewing = false;
+                render();
+            } else {
+                const remaining = LIVE_FULL_RENDER_MIN_INTERVAL - elapsed;
+                if (state.timer) clearTimeout(state.timer);
+                state.timer = setTimeout(() => {
+                    state.lastTime = performance.now();
+                    state.timer = null;
+                    if (isSimplePreviewing) isSimplePreviewing = false;
+                    if (imageTexture) render();
+                }, remaining);
+            }
+        }
         const sprocketSources = {
             'Spectra 100': './assets/grain/spectra100.png',
             'Spectra 400': './assets/grain/spectra400.png',
@@ -6626,6 +6682,7 @@ function applyBorderBlur() {
                 let initialClientY = 0, dragDirection = null, shouldZoomToFit = false;
                 const handleMove = (e) => {
                     if (!isDragging) return;
+                    const isLiveFullRenderSlider = LIVE_FULL_RENDER_SLIDER_IDS.has(slider.id);
                     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
                     const clientY = e.touches ? e.touches[0].clientY : e.clientY;
                     if (dragDirection === null) { 
@@ -6746,13 +6803,18 @@ function applyBorderBlur() {
                             if (slider.id.includes('diffusion') || slider.id === 'halationIntensity' || slider.id === 'mtfMask' || slider.id === 'mtfSoftness' || slider.id === 'blackpoint' || slider.id === 'whitepoint' || slider.id === 'thresholdGamma' || slider.id === 'coreBlur' || slider.id === 'midBlur' || slider.id === 'outerBlur' || slider.id === 'midBlurGain' || slider.id === 'outerBlurGain' || slider.id.includes('tintR2') || slider.id.includes('tintG2') || slider.id.includes('tintB2')) {
                                 invalidateDiffusionBuffer();
                             }
-                            if (imageTexture) render();
+                            if (isLiveFullRenderSlider) {
+                                triggerLiveFullRender(slider.id);
+                            } else if (imageTexture) {
+                                render();
+                            }
                         }
                         throttleTimeout = setTimeout(() => { throttleTimeout = null; }, 80);
                     }
                 };
                 const stopDrag = () => {
                     if (!isDragging) return;
+                    const isLiveFullRenderSlider = LIVE_FULL_RENDER_SLIDER_IDS.has(slider.id);
                     isDragging = false;
                     window.removeEventListener('mousemove', handleMove);
                     window.removeEventListener('touchmove', handleMove);
@@ -6806,12 +6868,18 @@ function applyBorderBlur() {
                         } else if (slider.id === 'framePadding') {
                             // Frame padding should render live without preview mode
                             if (imageTexture) render();
-                        } else { 
+                        } else {
                             // Invalidate diffusion cache for diffusion-related sliders at end of drag
                             if (slider.id.includes('diffusion') || slider.id === 'halationIntensity' || slider.id === 'mtfMask' || slider.id === 'mtfSoftness' || slider.id === 'blackpoint' || slider.id === 'whitepoint' || slider.id === 'thresholdGamma' || slider.id === 'coreBlur' || slider.id === 'midBlur' || slider.id === 'outerBlur' || slider.id === 'midBlurGain' || slider.id === 'outerBlurGain' || slider.id.includes('tintR2') || slider.id.includes('tintG2') || slider.id.includes('tintB2')) {
                                 invalidateDiffusionBuffer();
                             }
-                            if (imageTexture && slider.id !== 'maxResSlider') render(); 
+                            if (slider.id !== 'maxResSlider') {
+                                if (isLiveFullRenderSlider) {
+                                    triggerLiveFullRender(slider.id, true);
+                                } else if (imageTexture) {
+                                    render();
+                                }
+                            }
                         }
                     }
                 };
@@ -9447,64 +9515,64 @@ function applyBorderBlur() {
             diffusionTintRSlider.addEventListener('input', () => {
                 diffusionTintRValLabel.textContent = parseFloat(diffusionTintRSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintR');
             });
             diffusionTintRSlider.addEventListener('change', () => {
                 diffusionTintRValLabel.textContent = parseFloat(diffusionTintRSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintR', true);
             });
         }
         if (diffusionTintGSlider) {
             diffusionTintGSlider.addEventListener('input', () => {
                 diffusionTintGValLabel.textContent = parseFloat(diffusionTintGSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintG');
             });
             diffusionTintGSlider.addEventListener('change', () => {
                 diffusionTintGValLabel.textContent = parseFloat(diffusionTintGSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintG', true);
             });
         }
         if (diffusionTintBSlider) {
             diffusionTintBSlider.addEventListener('input', () => {
                 diffusionTintBValLabel.textContent = parseFloat(diffusionTintBSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintB');
             });
             diffusionTintBSlider.addEventListener('change', () => {
                 diffusionTintBValLabel.textContent = parseFloat(diffusionTintBSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionTintB', true);
             });
         }
-        
+
         // Diffusion spread slider event listeners
         if (diffusionSpreadSlider) {
             diffusionSpreadSlider.addEventListener('input', () => {
                 diffusionSpreadValLabel.textContent = parseFloat(diffusionSpreadSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionSpread');
             });
             diffusionSpreadSlider.addEventListener('change', () => {
                 diffusionSpreadValLabel.textContent = parseFloat(diffusionSpreadSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionSpread', true);
             });
         }
-        
+
         // Diffusion gamma slider event listeners
         if (diffusionGammaSlider) {
             diffusionGammaSlider.addEventListener('input', () => {
                 diffusionGammaValLabel.textContent = parseFloat(diffusionGammaSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionGamma');
             });
             diffusionGammaSlider.addEventListener('change', () => {
                 diffusionGammaValLabel.textContent = parseFloat(diffusionGammaSlider.value).toFixed(2);
                 invalidateDiffusionBuffer();
-                render();
+                triggerLiveFullRender('diffusionGamma', true);
             });
         }
         
@@ -9671,44 +9739,44 @@ function applyBorderBlur() {
         if (grainReduceShadowsSlider) {
             grainReduceShadowsSlider.addEventListener('input', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainReduceShadows');
             });
             grainReduceShadowsSlider.addEventListener('change', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainReduceShadows', true);
             });
         }
 
         if (grainShadowSatSlider) {
             grainShadowSatSlider.addEventListener('input', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainShadowSat');
             });
             grainShadowSatSlider.addEventListener('change', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainShadowSat', true);
             });
         }
 
         if (grainReduceHighlightsSlider) {
             grainReduceHighlightsSlider.addEventListener('input', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainReduceHighlights');
             });
             grainReduceHighlightsSlider.addEventListener('change', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainReduceHighlights', true);
             });
         }
 
         if (grainHighlightSatSlider) {
             grainHighlightSatSlider.addEventListener('input', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainHighlightSat');
             });
             grainHighlightSatSlider.addEventListener('change', () => {
                 updateSliderLabels();
-                if (imageTexture) render();
+                triggerLiveFullRender('grainHighlightSat', true);
             });
         }
 


### PR DESCRIPTION
## Summary
- add a shared helper to throttle full-path renders for optics, texture, and dust sliders while keeping proxy mode available for the original preview-only sliders
- update the draggable slider logic to use the new helper so targeted sliders stay on the full render path while dragging
- route existing slider input handlers in the optics/texture panels through the throttled live-render helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca768d87b88321b937a71c1c73a2a5